### PR TITLE
Use proper module name

### DIFF
--- a/controllers/config.go
+++ b/controllers/config.go
@@ -1,9 +1,10 @@
 package controllers
 
 import (
-	"cyndi-operator/controllers/config"
-	"cyndi-operator/controllers/utils"
 	"fmt"
+
+	"github.com/RedHatInsights/cyndi-operator/controllers/config"
+	"github.com/RedHatInsights/cyndi-operator/controllers/utils"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 )

--- a/controllers/config/config.go
+++ b/controllers/config/config.go
@@ -1,10 +1,11 @@
 package config
 
 import (
-	cyndi "cyndi-operator/api/v1alpha1"
-	"cyndi-operator/controllers/utils"
 	"fmt"
 	"strconv"
+
+	cyndi "github.com/RedHatInsights/cyndi-operator/api/v1alpha1"
+	"github.com/RedHatInsights/cyndi-operator/controllers/utils"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )

--- a/controllers/config/config_test.go
+++ b/controllers/config/config_test.go
@@ -1,11 +1,12 @@
 package config
 
 import (
-	"cyndi-operator/test"
 	"fmt"
 	"testing"
 
-	cyndi "cyndi-operator/api/v1alpha1"
+	"github.com/RedHatInsights/cyndi-operator/test"
+
+	cyndi "github.com/RedHatInsights/cyndi-operator/api/v1alpha1"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"

--- a/controllers/config/parsers_test.go
+++ b/controllers/config/parsers_test.go
@@ -2,9 +2,10 @@ package config
 
 import (
 	"context"
-	"cyndi-operator/test"
 	"fmt"
 	"time"
+
+	"github.com/RedHatInsights/cyndi-operator/test"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/controllers/connect/connect.go
+++ b/controllers/connect/connect.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"text/template"
 
-	. "cyndi-operator/controllers/config"
+	. "github.com/RedHatInsights/cyndi-operator/controllers/config"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/controllers/connect/connect_test.go
+++ b/controllers/connect/connect_test.go
@@ -2,14 +2,15 @@ package connect
 
 import (
 	"context"
-	cyndi "cyndi-operator/api/v1alpha1"
-	"cyndi-operator/test"
 	"fmt"
 	"testing"
 	"time"
 
-	. "cyndi-operator/controllers/config"
-	"cyndi-operator/controllers/utils"
+	cyndi "github.com/RedHatInsights/cyndi-operator/api/v1alpha1"
+	"github.com/RedHatInsights/cyndi-operator/test"
+
+	. "github.com/RedHatInsights/cyndi-operator/controllers/config"
+	"github.com/RedHatInsights/cyndi-operator/controllers/utils"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/controllers/cyndipipeline_controller.go
+++ b/controllers/cyndipipeline_controller.go
@@ -42,12 +42,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	cyndi "cyndi-operator/api/v1alpha1"
-	"cyndi-operator/controllers/config"
-	connect "cyndi-operator/controllers/connect"
-	"cyndi-operator/controllers/database"
-	"cyndi-operator/controllers/metrics"
-	"cyndi-operator/controllers/utils"
+	cyndi "github.com/RedHatInsights/cyndi-operator/api/v1alpha1"
+	"github.com/RedHatInsights/cyndi-operator/controllers/config"
+	connect "github.com/RedHatInsights/cyndi-operator/controllers/connect"
+	"github.com/RedHatInsights/cyndi-operator/controllers/database"
+	"github.com/RedHatInsights/cyndi-operator/controllers/metrics"
+	"github.com/RedHatInsights/cyndi-operator/controllers/utils"
 )
 
 // CyndiPipelineReconciler reconciles a CyndiPipeline object

--- a/controllers/cyndipipeline_controller_test.go
+++ b/controllers/cyndipipeline_controller_test.go
@@ -27,7 +27,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	cyndi "cyndi-operator/api/v1alpha1"
+	cyndi "github.com/RedHatInsights/cyndi-operator/api/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -36,11 +36,11 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
 
-	. "cyndi-operator/controllers/config"
-	connect "cyndi-operator/controllers/connect"
-	"cyndi-operator/controllers/database"
-	"cyndi-operator/controllers/utils"
-	"cyndi-operator/test"
+	. "github.com/RedHatInsights/cyndi-operator/controllers/config"
+	connect "github.com/RedHatInsights/cyndi-operator/controllers/connect"
+	"github.com/RedHatInsights/cyndi-operator/controllers/database"
+	"github.com/RedHatInsights/cyndi-operator/controllers/utils"
+	"github.com/RedHatInsights/cyndi-operator/test"
 	// +kubebuilder:scaffold:imports
 )
 

--- a/controllers/database/app_database.go
+++ b/controllers/database/app_database.go
@@ -2,11 +2,12 @@ package database
 
 import (
 	"bytes"
-	"cyndi-operator/controllers/config"
-	"cyndi-operator/controllers/utils"
 	"fmt"
 	"strings"
 	"text/template"
+
+	"github.com/RedHatInsights/cyndi-operator/controllers/config"
+	"github.com/RedHatInsights/cyndi-operator/controllers/utils"
 )
 
 type AppDatabase struct {

--- a/controllers/database/app_database_test.go
+++ b/controllers/database/app_database_test.go
@@ -1,7 +1,7 @@
 package database
 
 import (
-	. "cyndi-operator/controllers/config"
+	. "github.com/RedHatInsights/cyndi-operator/controllers/config"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/controllers/database/database.go
+++ b/controllers/database/database.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/jackc/pgx"
 
-	"cyndi-operator/controllers/config"
-	. "cyndi-operator/controllers/config"
+	"github.com/RedHatInsights/cyndi-operator/controllers/config"
+	. "github.com/RedHatInsights/cyndi-operator/controllers/config"
 )
 
 type BaseDatabase struct {

--- a/controllers/database/database_test.go
+++ b/controllers/database/database_test.go
@@ -1,9 +1,10 @@
 package database
 
 import (
-	"cyndi-operator/test"
 	"fmt"
 	"testing"
+
+	"github.com/RedHatInsights/cyndi-operator/test"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/controllers/database/test_common.go
+++ b/controllers/database/test_common.go
@@ -1,9 +1,10 @@
 package database
 
 import (
-	. "cyndi-operator/controllers/config"
 	"fmt"
 	"time"
+
+	. "github.com/RedHatInsights/cyndi-operator/controllers/config"
 
 	"github.com/spf13/viper"
 )

--- a/controllers/diff.go
+++ b/controllers/diff.go
@@ -1,9 +1,10 @@
 package controllers
 
 import (
-	"cyndi-operator/controllers/utils"
 	"fmt"
 	"strings"
+
+	"github.com/RedHatInsights/cyndi-operator/controllers/utils"
 
 	"github.com/google/go-cmp/cmp"
 )

--- a/controllers/integration_test.go
+++ b/controllers/integration_test.go
@@ -2,14 +2,15 @@ package controllers
 
 import (
 	"context"
-	cyndi "cyndi-operator/api/v1alpha1"
-	connect "cyndi-operator/controllers/connect"
-	"cyndi-operator/controllers/database"
-	"cyndi-operator/controllers/utils"
-	"cyndi-operator/test"
 	"fmt"
 
-	. "cyndi-operator/controllers/config"
+	cyndi "github.com/RedHatInsights/cyndi-operator/api/v1alpha1"
+	connect "github.com/RedHatInsights/cyndi-operator/controllers/connect"
+	"github.com/RedHatInsights/cyndi-operator/controllers/database"
+	"github.com/RedHatInsights/cyndi-operator/controllers/utils"
+	"github.com/RedHatInsights/cyndi-operator/test"
+
+	. "github.com/RedHatInsights/cyndi-operator/controllers/config"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/controllers/iteration.go
+++ b/controllers/iteration.go
@@ -2,12 +2,13 @@ package controllers
 
 import (
 	"context"
-	cyndi "cyndi-operator/api/v1alpha1"
-	"cyndi-operator/controllers/config"
-	"cyndi-operator/controllers/database"
 	"fmt"
 	"strings"
 	"time"
+
+	cyndi "github.com/RedHatInsights/cyndi-operator/api/v1alpha1"
+	"github.com/RedHatInsights/cyndi-operator/controllers/config"
+	"github.com/RedHatInsights/cyndi-operator/controllers/database"
 
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"

--- a/controllers/metrics/metrics.go
+++ b/controllers/metrics/metrics.go
@@ -4,7 +4,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
-	cyndi "cyndi-operator/api/v1alpha1"
+	cyndi "github.com/RedHatInsights/cyndi-operator/api/v1alpha1"
 )
 
 var (

--- a/controllers/probes.go
+++ b/controllers/probes.go
@@ -1,6 +1,6 @@
 package controllers
 
-import "cyndi-operator/controllers/metrics"
+import "github.com/RedHatInsights/cyndi-operator/controllers/metrics"
 
 func (i *ReconcileIteration) probeStartingInitialSync() {
 	i.Log.Info("New pipeline version", "version", i.Instance.Status.PipelineVersion)

--- a/controllers/utils/k8s.go
+++ b/controllers/utils/k8s.go
@@ -12,7 +12,7 @@ import (
 	"fmt"
 	"hash/fnv"
 
-	cyndi "cyndi-operator/api/v1alpha1"
+	cyndi "github.com/RedHatInsights/cyndi-operator/api/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/controllers/utils/misc.go
+++ b/controllers/utils/misc.go
@@ -1,8 +1,9 @@
 package utils
 
 import (
-	cyndi "cyndi-operator/api/v1alpha1"
 	"fmt"
+
+	cyndi "github.com/RedHatInsights/cyndi-operator/api/v1alpha1"
 )
 
 const inventorySchema = "inventory"

--- a/controllers/validate.go
+++ b/controllers/validate.go
@@ -1,9 +1,10 @@
 package controllers
 
 import (
-	"cyndi-operator/controllers/metrics"
-	"cyndi-operator/controllers/utils"
 	"math"
+
+	"github.com/RedHatInsights/cyndi-operator/controllers/metrics"
+	"github.com/RedHatInsights/cyndi-operator/controllers/utils"
 )
 
 const inventoryTableName = "public.hosts" // TODO: move

--- a/controllers/validation_controller.go
+++ b/controllers/validation_controller.go
@@ -2,9 +2,10 @@ package controllers
 
 import (
 	"context"
-	cyndi "cyndi-operator/api/v1alpha1"
-	"cyndi-operator/controllers/database"
 	"fmt"
+
+	cyndi "github.com/RedHatInsights/cyndi-operator/api/v1alpha1"
+	"github.com/RedHatInsights/cyndi-operator/controllers/database"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/controllers/validation_controller_test.go
+++ b/controllers/validation_controller_test.go
@@ -2,16 +2,17 @@ package controllers
 
 import (
 	"context"
-	cyndi "cyndi-operator/api/v1alpha1"
-	"cyndi-operator/controllers/database"
-	"cyndi-operator/controllers/utils"
-	"cyndi-operator/test"
 	"fmt"
+
+	cyndi "github.com/RedHatInsights/cyndi-operator/api/v1alpha1"
+	"github.com/RedHatInsights/cyndi-operator/controllers/database"
+	"github.com/RedHatInsights/cyndi-operator/controllers/utils"
+	"github.com/RedHatInsights/cyndi-operator/test"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	. "cyndi-operator/controllers/config"
+	. "github.com/RedHatInsights/cyndi-operator/controllers/config"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module cyndi-operator
+module github.com/RedHatInsights/cyndi-operator
 
 go 1.13
 

--- a/main.go
+++ b/main.go
@@ -29,9 +29,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	cyndi "cyndi-operator/api/v1alpha1"
-	"cyndi-operator/controllers"
-	"cyndi-operator/controllers/metrics"
+	cyndi "github.com/RedHatInsights/cyndi-operator/api/v1alpha1"
+	"github.com/RedHatInsights/cyndi-operator/controllers"
+	"github.com/RedHatInsights/cyndi-operator/controllers/metrics"
 	// +kubebuilder:scaffold:imports
 )
 

--- a/test/setup.go
+++ b/test/setup.go
@@ -18,7 +18,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	cyndi "cyndi-operator/api/v1alpha1"
+	cyndi "github.com/RedHatInsights/cyndi-operator/api/v1alpha1"
 )
 
 var Client client.Client


### PR DESCRIPTION
So that `go get` works:

```
Error: go [-e -json -compiled=true -test=false -export=false -deps=true -find=false -tags ignore_autogenerated -- ./...]: exit status 1: go: github.com/RedHatInsights/cyndi-operator@v0.1.3: parsing go.mod:
	module declares its path as: cyndi-operator
	        but was required as: github.com/RedHatInsights/cyndi-operator
```