### PR TITLE
Revert "RHCLOUD-23979 use ubi8-minimal image as the base for cyndi's image"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,17 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi8/go-toolset:1.17.12 as builder
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest as builder
+
 
 USER 0
+
+# the latest go version available now is 1.18.9
+RUN microdnf install --setopt=tsflags=nodocs -y go-toolset-1.18.9 && \
+    microdnf install -y rsync tar procps-ng && \
+    microdnf upgrade -y && \
+    microdnf clean all
+
 WORKDIR /workspace
+
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,7 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.17.12 as builder
 
 USER 0
-
-# the latest go version available now is 1.18.9
-RUN microdnf install --setopt=tsflags=nodocs -y go-toolset-1.18.9 && \
-    microdnf install -y rsync tar procps-ng && \
-    microdnf upgrade -y && \
-    microdnf clean all
-
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,8 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest as builder
-
+FROM registry.access.redhat.com/ubi8/go-toolset:1.17.12 as builder
 
 USER 0
-
-# the latest go version available now is 1.18.9
-RUN microdnf install --setopt=tsflags=nodocs -y go-toolset-1.18.9 && \
-    microdnf install -y rsync tar procps-ng && \
-    microdnf upgrade -y && \
-    microdnf clean all
-
 WORKDIR /workspace
-
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum


### PR DESCRIPTION
Reverts RedHatInsights/cyndi-operator#77.  Reverting this change because the final image should be `ubi-minimal` based and NOT distroless.