### PR TITLE
RHCLOUD-23979 update docker file to include ubi-minimal in the final image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,6 @@ RUN microdnf install --setopt=tsflags=nodocs -y go-toolset-1.18.9 && \
 
 WORKDIR /
 
-# TODO: remove go installation check 
-RUN go version
-
 COPY --from=builder /workspace/manager .
 USER nonroot:nonroot
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,17 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi8/go-toolset:1.17.12 as builder
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest as builder
+
 
 USER 0
+
+# the latest go version available now is 1.18.9
+RUN microdnf install --setopt=tsflags=nodocs -y go-toolset-1.18.9 && \
+    microdnf install -y rsync tar procps-ng && \
+    microdnf upgrade -y && \
+    microdnf clean all
+
 WORKDIR /workspace
+
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,8 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest as builder
-
+FROM registry.access.redhat.com/ubi8/go-toolset:1.17.12 as builder
 
 USER 0
-
-# the latest go version available now is 1.18.9
-RUN microdnf install --setopt=tsflags=nodocs -y go-toolset-1.18.9 && \
-    microdnf install -y rsync tar procps-ng && \
-    microdnf upgrade -y && \
-    microdnf clean all
-
 WORKDIR /workspace
-
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,14 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi8/go-toolset:1.17.12 as builder
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest as builder
 
 USER 0
+
+# the latest go version available now is 1.18.9
+RUN microdnf install --setopt=tsflags=nodocs -y go-toolset-1.18.9 && \
+    microdnf install -y rsync tar procps-ng && \
+    microdnf upgrade -y && \
+    microdnf clean all
+
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod


### PR DESCRIPTION
This change is made so that the final image uploaded to cloudservices is `ubi-minimal` based.  The previous update would make `gcr.io/distroless/static:nonroot` as the base image, which would not work for fedramp