### PR TITLE
Draft ci: Add GitHub actions for linting Go code

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,41 @@
+name: Lint
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  lint-code:
+    name: Lint code
+    runs-on: ubuntu-latest
+    steps:
+      - name: Updating ...
+        run: sudo apt-get -qq update
+
+      - name: Set up go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.18"
+          cache: false
+
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: "latest"
+          args: "--verbose --timeout 5m"
+
+  lint-language:
+    name: Lint language
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Run woke
+        uses: get-woke/woke-action@v0
+        with:
+          fail-on-error: false

--- a/api/v1alpha1/state.go
+++ b/api/v1alpha1/state.go
@@ -30,7 +30,7 @@ func (instance *CyndiPipeline) GetState() PipelineState {
 		return STATE_NEW
 	case instance.IsValid():
 		return STATE_VALID
-	case instance.Status.InitialSyncInProgress == true:
+	case instance.Status.InitialSyncInProgress:
 		return STATE_INITIAL_SYNC
 	case instance.GetValid() == metav1.ConditionFalse:
 		return STATE_INVALID
@@ -39,11 +39,10 @@ func (instance *CyndiPipeline) GetState() PipelineState {
 	}
 }
 
-func (instance *CyndiPipeline) TransitionToNew() error {
+func (instance *CyndiPipeline) TransitionToNew() {
 	instance.ResetValid()
 	instance.Status.InitialSyncInProgress = false
 	instance.Status.PipelineVersion = ""
-	return nil
 }
 
 func (instance *CyndiPipeline) TransitionToInitialSync(pipelineVersion string) error {
@@ -114,7 +113,7 @@ func TableName(pipelineVersion string) string {
 }
 
 func TableNameToConnectorName(tableName string, appName string) string {
-	return ConnectorName(string(tableName[len(tablePrefix):len(tableName)]), appName)
+	return ConnectorName(string(tableName[len(tablePrefix):]), appName)
 }
 
 func ConnectorName(pipelineVersion string, appName string) string {

--- a/controllers/cyndipipeline_controller.go
+++ b/controllers/cyndipipeline_controller.go
@@ -130,12 +130,10 @@ func (r *CyndiPipelineReconciler) Reconcile(ctx context.Context, request ctrl.Re
 	reqLogger.Info("Reconciling CyndiPipeline")
 
 	i, err := r.setup(reqLogger, request, ctx)
-	defer i.Close()
-
 	if err != nil {
-		_ = i.error(err)
-		setupErrors = append(setupErrors, err)
+		setupErrors = append(setupErrors, i.error(err))
 	}
+	defer i.Close()
 
 	// Request object not found, could have been deleted after reconcile request.
 	if i.Instance == nil {
@@ -186,7 +184,9 @@ func (r *CyndiPipelineReconciler) Reconcile(ctx context.Context, request ctrl.Re
 		i.Instance.Status.SpecHash = i.config.SpecHash
 
 		pipelineVersion := fmt.Sprintf("1_%s", strconv.FormatInt(time.Now().UnixNano(), 10))
-		i.Instance.TransitionToInitialSync(pipelineVersion)
+		if err := i.Instance.TransitionToInitialSync(pipelineVersion); err != nil {
+			return reconcile.Result{}, i.error(err, "Error Transitioning to initial state")
+		}
 		i.probeStartingInitialSync()
 
 		err = i.AppDb.CreateTable(cyndi.TableName(pipelineVersion), i.config.DBTableInitScript+i.config.DBTableIndexSQL)
@@ -394,7 +394,7 @@ func (i *ReconcileIteration) checkForDeviation() (problem error, err error) {
 	dbTableExists, err := i.AppDb.CheckIfTableExists(i.Instance.Status.TableName)
 	if err != nil {
 		return nil, err
-	} else if dbTableExists == false {
+	} else if !dbTableExists {
 		return fmt.Errorf("Database table %s not found", i.Instance.Status.TableName), nil
 	}
 

--- a/controllers/database/app_database.go
+++ b/controllers/database/app_database.go
@@ -115,7 +115,7 @@ func (db *AppDatabase) DeleteTable(tableName string) error {
 	tableExists, err := db.CheckIfTableExists(tableName)
 	if err != nil {
 		return err
-	} else if tableExists != true {
+	} else if !tableExists {
 		return nil
 	}
 

--- a/controllers/iteration.go
+++ b/controllers/iteration.go
@@ -84,7 +84,7 @@ func (i *ReconcileIteration) debug(message string, keysAndValues ...interface{})
 }
 
 func (i *ReconcileIteration) getValidationConfig() config.ValidationConfiguration {
-	if i.Instance.Status.InitialSyncInProgress == true {
+	if i.Instance.Status.InitialSyncInProgress {
 		return i.config.ValidationConfigInit
 	}
 

--- a/controllers/validation_controller.go
+++ b/controllers/validation_controller.go
@@ -54,11 +54,10 @@ func (r *ValidationReconciler) Reconcile(ctx context.Context, request ctrl.Reque
 	reqLogger := r.Log.WithValues("Pipeline", request.Name, "Namespace", request.Namespace)
 
 	i, err := r.setup(reqLogger, request, ctx)
-	defer i.Close()
-
 	if err != nil {
 		return reconcile.Result{}, i.error(err)
 	}
+	defer i.Close()
 
 	// nothing to validate
 	if i.Instance == nil || i.Instance.GetState() == cyndi.STATE_REMOVED || i.Instance.GetState() == cyndi.STATE_NEW {
@@ -123,7 +122,7 @@ func eventFilterPredicate() predicate.Predicate {
 			oldPipeline, ok1 := e.ObjectOld.(*cyndi.CyndiPipeline)
 			newPipeline, ok2 := e.ObjectNew.(*cyndi.CyndiPipeline)
 
-			if ok1 && ok2 && oldPipeline.Status.InitialSyncInProgress == false && newPipeline.Status.InitialSyncInProgress == true {
+			if ok1 && ok2 && !oldPipeline.Status.InitialSyncInProgress && newPipeline.Status.InitialSyncInProgress {
 				return true // pipeline refresh happened - validate the new pipeline
 			}
 


### PR DESCRIPTION
This patch adds actions to lint Go code with `golangci-lint`, and fixes all the issues returned by this tool. It also includes tooling to detect non-inclusive language in the source code. Note that is non voting for now.