### PR TITLE
Support arm64 and amd64 builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY api/ api/
 COPY controllers/ controllers/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -13,5 +13,13 @@ fi
 DOCKER_CONF="$PWD/.docker"
 mkdir -p "$DOCKER_CONF"
 docker --config="$DOCKER_CONF" login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
-docker --config="$DOCKER_CONF" build -t "${IMAGE}:${IMAGE_TAG}" .
-docker --config="$DOCKER_CONF" push "${IMAGE}:${IMAGE_TAG}"
+
+
+docker --config="$DOCKER_CONF" build --platform="linux/amd64" -t "${IMAGE}:${IMAGE_TAG}-amd64" --push .
+docker --config="$DOCKER_CONF" build --platform="linux/arm64" -t "${IMAGE}:${IMAGE_TAG}-arm64" --push .
+
+docker --config="$DOCKER_CONF" manifest create "${IMAGE}:${IMAGE_TAG}" \
+    "${IMAGE}:${IMAGE_TAG}-amd64" \
+    "${IMAGE}:${IMAGE_TAG}-arm64"
+
+docker --config="$DOCKER_CONF" manifest push "${IMAGE}:${IMAGE_TAG}"


### PR DESCRIPTION
This patch modifies the Dockerfile and build_deploy.sh scripts to support building images for both arm64 and amd64 and then pushes a manifest up to quay. This patch doesn't touch the build_catalog.sh script because its out of scope for the project I'm working on. The goal here is to allow developers to work on clowder and frontend operator on arm64 systems, and that currently isn't possible because the cyndi operator wont run on arm64 systems.