### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners
+* @RedHatInsights/host-based-inventory-committers


### PR DESCRIPTION
Adds the HBI committers team to the CODEOWNERS file so that we get added as reviewers to new PRs.