### PR TITLE
fix: remove go-toolset from running image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager 
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
-RUN microdnf install --setopt=tsflags=nodocs -y go-toolset && \
-    microdnf install -y rsync tar procps-ng && \
+RUN microdnf install -y rsync tar procps-ng && \
     microdnf upgrade -y && \
     microdnf clean all
 


### PR DESCRIPTION
The go toolset isn't required for the running image and increases the vulnerability footprint of the image overall. We can remove it without impacting the cyndi operator itself.