### PR TITLE
Update go toolset and remove debug tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi8/go-toolset:1.18.10 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.20.12 as builder
 
 USER 0
 WORKDIR /workspace
@@ -21,10 +21,6 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
-
-RUN microdnf install -y rsync tar procps-ng && \
-    microdnf upgrade -y && \
-    microdnf clean all
 
 WORKDIR /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager 
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
-RUN microdnf install --setopt=tsflags=nodocs -y go-toolset && \
-    microdnf install -y rsync tar procps-ng && \
+RUN microdnf install -y rsync tar procps-ng && \
     microdnf upgrade -y && \
     microdnf clean all
 

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -27,6 +27,7 @@ else
 fi
 
 if [[ "$GIT_BRANCH" == "origin/security-compliance" ]]; then
+    docker build -t "${IMAGE}:${IMAGE_TAG}" .
     docker  tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:${SECURITY_COMPLIANCE_TAG}"
     docker  push "${IMAGE}:${SECURITY_COMPLIANCE_TAG}"
 fi


### PR DESCRIPTION
updating the go toolset to 1.20, which is most current and free of vulnerabilities.

Also removing the extra tools that are not needed for the app to work.