### PR TITLE
Use HBI's read-replicas rather than main DBs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The `additionalFilter` expects an array of objects (defaults to `[]`) describing
 * A PostgreSQL database to be used as the target database
   * [Onboarding process](https://consoledot.pages.redhat.com/docs/dev/services/inventory.html#_onboarding_process) has been completed on the target database
   An OpenShift secret with database credentials is stored in the Kafka Connect namespace and named `{appName}-db`, where `appName` is the name used in pipeline definition. If needed, the name of the secret used can be changed by setting `dbSecret` in the `CyndiPipeline` spec.
-* An OpenShift secret named `host-inventory-db` containing Inventory database credentials (used for validation) is present in the Kafka Connect namespace. The name of the secret used can be changed by setting `inventory.dbSecret` in the cyndi `ConfigMap`, or by setting `inventoryDbSecret` in the `CyndiPipeline` spec.
+* An OpenShift secret named `host-inventory-read-only-db` containing Inventory database credentials (used for validation) is present in the Kafka Connect namespace. The name of the secret used can be changed by setting `inventory.dbSecret` in the cyndi `ConfigMap`, or by setting `inventoryDbSecret` in the `CyndiPipeline` spec.
 
 
 ## Implementation
@@ -218,14 +218,14 @@ Then, the CR can be managed via Kubernetes commands like normal.
 
 - List hosts
     ```
-    psql -U "$HBI_USER" -h host-inventory-db -p 5432 -d "$HBI_NAME" -c "SELECT * FROM HOSTS;"
+    psql -U "$HBI_USER" -h host-inventory-read-only-db -p 5432 -d "$HBI_NAME" -c "SELECT * FROM HOSTS;"
     ```
 
 - Access the kafka connect API at http://connect-connect-api.test.svc:8083/connectors
 
 - Connect to inventory db
     ```
-    psql -U "$HBI_USER" -h host-inventory-db -p 5432 -d "$HBI_NAME"
+    psql -U "$HBI_USER" -h host-inventory-read-only-db -p 5432 -d "$HBI_NAME"
     ```
 
 - Connect to advisor db

--- a/controllers/config/defaults.go
+++ b/controllers/config/defaults.go
@@ -2,7 +2,7 @@ package config
 
 const defaultTopic = "platform.inventory.events"
 const defaultConnectCluster = "xjoin-kafka-connect-strimzi"
-const defaultInventoryDbSecret = "host-inventory-db"
+const defaultInventoryDbSecret = "host-inventory-read-only-db"
 
 const defaultConnectorTemplate = `{
 	"connector.class": "io.confluent.connect.jdbc.JdbcSinkConnector",

--- a/controllers/cyndipipeline_controller_test.go
+++ b/controllers/cyndipipeline_controller_test.go
@@ -19,8 +19,9 @@ package controllers
 import (
 	"context"
 	"fmt"
-	logr "github.com/go-logr/logr/testing"
 	"testing"
+
+	logr "github.com/go-logr/logr/testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -192,7 +193,7 @@ var _ = Describe("Pipeline operations", func() {
 
 		dbParams = getDBParams()
 
-		createDbSecret(namespacedName.Namespace, "host-inventory-db", dbParams)
+		createDbSecret(namespacedName.Namespace, "host-inventory-read-only-db", dbParams)
 		createDbSecret(namespacedName.Namespace, utils.AppDefaultDbSecretName(namespacedName.Name), dbParams)
 
 		db = database.NewAppDatabase(&dbParams, logr.TestLogger{})
@@ -265,7 +266,7 @@ var _ = Describe("Pipeline operations", func() {
 
 		It("Considers inventory db secret name configuration", func() {
 			// remove the app db secret and create a secret with non-standard name
-			inventoryDbSecret, err := utils.FetchSecret(test.Client, namespacedName.Namespace, "host-inventory-db")
+			inventoryDbSecret, err := utils.FetchSecret(test.Client, namespacedName.Namespace, "host-inventory-read-only-db")
 			Expect(err).ToNot(HaveOccurred())
 			err = test.Client.Delete(context.TODO(), inventoryDbSecret)
 			Expect(err).ToNot(HaveOccurred())

--- a/controllers/integration_test.go
+++ b/controllers/integration_test.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+
 	logr "github.com/go-logr/logr/testing"
 
 	cyndi "github.com/RedHatInsights/cyndi-operator/api/v1alpha1"
@@ -73,7 +74,7 @@ var _ = Describe("Integration tests", func() {
 
 		dbParams = getDBParams()
 
-		createDbSecret(namespacedName.Namespace, "host-inventory-db", dbParams)
+		createDbSecret(namespacedName.Namespace, "host-inventory-read-only-db", dbParams)
 		createDbSecret(namespacedName.Namespace, utils.AppDefaultDbSecretName(namespacedName.Name), dbParams)
 
 		appDb = database.NewAppDatabase(&dbParams, logr.TestLogger{})

--- a/controllers/validation_controller_test.go
+++ b/controllers/validation_controller_test.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+
 	logr "github.com/go-logr/logr/testing"
 
 	cyndi "github.com/RedHatInsights/cyndi-operator/api/v1alpha1"
@@ -83,7 +84,7 @@ var _ = Describe("Validation controller", func() {
 
 		dbParams = getDBParams()
 
-		createDbSecret(namespacedName.Namespace, "host-inventory-db", dbParams)
+		createDbSecret(namespacedName.Namespace, "host-inventory-read-only-db", dbParams)
 		createDbSecret(namespacedName.Namespace, utils.AppDefaultDbSecretName(namespacedName.Name), dbParams)
 
 		appDb = database.NewAppDatabase(&dbParams, logr.TestLogger{})
@@ -328,7 +329,7 @@ var _ = Describe("Validation controller", func() {
 
 	Describe("Failures", func() {
 		It("Fails if HBI DB secret is missing", func() {
-			dbSecret, err := utils.FetchSecret(test.Client, namespacedName.Namespace, "host-inventory-db")
+			dbSecret, err := utils.FetchSecret(test.Client, namespacedName.Namespace, "host-inventory-read-only-db")
 			Expect(err).ToNot(HaveOccurred())
 			dbSecret.Data["db.host"] = []byte("localhost")
 			dbSecret.Data["db.port"] = []byte("55432")

--- a/dev/forward-ports.sh
+++ b/dev/forward-ports.sh
@@ -15,7 +15,7 @@ CONNECT_NAME=$(kubectl get kafkaconnect -o custom-columns=:metadata.name -n "$PR
 KAFKA_SVC="svc/$KAFKA_NAME-kafka-bootstrap"
 CONNECT_SVC="svc/$CONNECT_NAME-connect-api"
 ELASTICSEARCH_SVC="svc/xjoin-elasticsearch-es-default"
-HBI_DB_SVC="svc/host-inventory-db"
+HBI_DB_SVC="svc/host-inventory-read-only-db"
 XJOIN_SVC="svc/xjoin-search"
 HBI_SVC="svc/host-inventory-service"
 APICURIO_SVC="svc/xjoin-apicurio-service"

--- a/dev/forward-ports.sh
+++ b/dev/forward-ports.sh
@@ -15,7 +15,7 @@ CONNECT_NAME=$(kubectl get kafkaconnect -o custom-columns=:metadata.name -n "$PR
 KAFKA_SVC="svc/$KAFKA_NAME-kafka-bootstrap"
 CONNECT_SVC="svc/$CONNECT_NAME-connect-api"
 ELASTICSEARCH_SVC="svc/xjoin-elasticsearch-es-default"
-HBI_DB_SVC="svc/host-inventory-read-only-db"
+HBI_DB_SVC="svc/host-inventory-db"
 XJOIN_SVC="svc/xjoin-search"
 HBI_SVC="svc/host-inventory-service"
 APICURIO_SVC="svc/xjoin-apicurio-service"

--- a/dev/inventory-api.yml
+++ b/dev/inventory-api.yml
@@ -47,17 +47,17 @@ spec:
           valueFrom:
             secretKeyRef:
               key: db.host
-              name: host-inventory-db
+              name: host-inventory-read-only-db
         - name: INVENTORY_DB_USER
           valueFrom:
             secretKeyRef:
               key: db.user
-              name: host-inventory-db
+              name: host-inventory-read-only-db
         - name: INVENTORY_DB_PASS
           valueFrom:
             secretKeyRef:
               key: db.password
-              name: host-inventory-db
+              name: host-inventory-read-only-db
         - name: INVENTORY_DB_NAME
           value: insights
         - name: APP_NAME

--- a/dev/inventory-db.secret.yml
+++ b/dev/inventory-db.secret.yml
@@ -7,5 +7,5 @@ data:
   db.port: NTQzMg==
 kind: Secret
 metadata:
-  name: host-inventory-db
+  name: host-inventory-read-only-db
 type: Opaque

--- a/dev/inventory-db.yaml
+++ b/dev/inventory-db.yaml
@@ -40,17 +40,17 @@ spec:
           valueFrom:
             secretKeyRef:
               key: db.user
-              name: host-inventory-db
+              name: host-inventory-read-only-db
         - name: POSTGRESQL_PASSWORD
           valueFrom:
             secretKeyRef:
               key: db.password
-              name: host-inventory-db
+              name: host-inventory-read-only-db
         - name: POSTGRESQL_DATABASE
           valueFrom:
             secretKeyRef:
               key: db.name
-              name: host-inventory-db
+              name: host-inventory-read-only-db
         image: registry.redhat.io/rhscl/postgresql-12-rhel7
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/dev/inventory-mq.yml
+++ b/dev/inventory-mq.yml
@@ -51,22 +51,22 @@ spec:
           valueFrom:
             secretKeyRef:
               key: db.host
-              name: host-inventory-db
+              name: host-inventory-read-only-db
         - name: INVENTORY_DB_PORT
           valueFrom:
             secretKeyRef:
               key: db.port
-              name: host-inventory-db
+              name: host-inventory-read-only-db
         - name: INVENTORY_DB_USER
           valueFrom:
             secretKeyRef:
               key: db.user
-              name: host-inventory-db
+              name: host-inventory-read-only-db
         - name: INVENTORY_DB_PASS
           valueFrom:
             secretKeyRef:
               key: db.password
-              name: host-inventory-db
+              name: host-inventory-read-only-db
         - name: INVENTORY_DB_NAME
           value: insights
         - name: INVENTORY_LOG_LEVEL


### PR DESCRIPTION
This PR switches out references to `host-inventory-db` for `host-inventory-read-only-db`. Makes it so Cyndi uses the read replicas rather than the main DB.