### PR TITLE
RHINENG-10912: add an auto-updating timestamp field on the table

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,3 +237,6 @@ Then, the CR can be managed via Kubernetes commands like normal.
     ```
     opm index export --index=quay.io/cloudservices/cyndi-operator-index:local -c podman
     ```
+
+## Synchronization delay
+As the service does asynchronous replication, a small amount of inconsistency is always expected over time. There is always a slight delay between the appearance of a system in the inventory database and the syndicated application databases. In order to measure this delay over time, the `syndicated` field is automatically populated in the target tables with the current timestamp of the moment when a row is created/updated. The replication delay can be calculated by subtracting the `updated` timestamp from this value.

--- a/controllers/config/defaults.go
+++ b/controllers/config/defaults.go
@@ -98,6 +98,7 @@ CREATE TABLE inventory.{{.TableName}} (
 	tags jsonb NOT NULL,
 	updated timestamp with time zone NOT NULL,
 	created timestamp with time zone NOT NULL,
+	syndicated timestamp with time zone DEFAULT CURRENT_TIMESTAMP,
 	stale_timestamp timestamp with time zone NOT NULL,
 	system_profile jsonb NOT NULL,
 	insights_id uuid,
@@ -106,6 +107,17 @@ CREATE TABLE inventory.{{.TableName}} (
 	org_id character varying(36),
 	groups jsonb
 );
+
+CREATE OR REPLACE FUNCTION update_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.syndicated = CURRENT_TIMESTAMP;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER set_timestamp BEFORE INSERT OR UPDATE ON inventory.{{.TableName}}
+FOR EACH ROW EXECUTE FUNCTION update_timestamp();
 `
 
 const defaultDBTableIndexSQL = `

--- a/controllers/database/app_database.go
+++ b/controllers/database/app_database.go
@@ -21,6 +21,7 @@ const viewTemplate = `CREATE OR REPLACE VIEW inventory.hosts AS SELECT
 	display_name,
 	created,
 	updated,
+	syndicated,
 	stale_timestamp,
 	stale_timestamp + INTERVAL '1' DAY * '%[2]s' AS stale_warning_timestamp,
 	stale_timestamp + INTERVAL '1' DAY * '%[3]s' AS culled_timestamp,


### PR DESCRIPTION
This new `syndicated` field would be useful to measure the delay between the change in the inventory DB and the actual write of the row in the application DBs. The important piece is that it is not using Kafka to measure the lag.