### PR TITLE
security: update opm_version and golang version in catalog

### DIFF
--- a/build_catalog.sh
+++ b/build_catalog.sh
@@ -42,14 +42,14 @@ build_a_tag() {
   fi
   
   version="0.1.$num_commits-git$current_commit"
-  opm_version="1.24.0"
+  opm_version="1.45.0"
 
   # Download opm build
   curl -L https://github.com/operator-framework/operator-registry/releases/download/v$opm_version/linux-amd64-opm -o ./opm
   chmod u+x ./opm
 
   # workaround for https://github.com/golang/go/issues/38373
-  GO_VERSION="1.18.10"
+  GO_VERSION="1.22.6"
   GOUNPACK=$(mktemp -d)
   wget -q "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" -O $GOUNPACK/go.tar.gz
   tar -C $GOUNPACK -xzf $GOUNPACK/go.tar.gz


### PR DESCRIPTION
There are CVEs related to the operator source and catalog that we need to resolve. These are the latest versions of opm and go and this PR is an attempt to see if these version work