### PR TITLE
Remove OLM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,8 @@ bundle-build: bundle
 	docker build -f bundle.Dockerfile -t $(BUNDLE_IMAGE):$(BUNDLE_IMAGE_TAG) .
 
 build-template: manifests kustomize controller-gen
-	$(KUSTOMIZE) build config/default | ./manifest2template.py > deploy.yml 
+	$(KUSTOMIZE) build config/deployment-template | ./manifest2template.py > deploy.yml
+	sed -i '/ConfigMap/{n;n;s/cyndi-operator-//;:a;n;ba;}' deploy.yml 
 
 # Create a release manifest file
 release: manifests kustomize

--- a/Makefile
+++ b/Makefile
@@ -165,6 +165,9 @@ endif
 bundle-build: bundle
 	docker build -f bundle.Dockerfile -t $(BUNDLE_IMAGE):$(BUNDLE_IMAGE_TAG) .
 
+build-template: manifests kustomize controller-gen
+	$(KUSTOMIZE) build config/default | ./manifest2template.py > deploy.yml 
+
 # Create a release manifest file
 release: manifests kustomize
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}

--- a/config/default/cyndi_configmap.yaml
+++ b/config/default/cyndi_configmap.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cyndi
+data:
+  standard.interval: ${RECONCILE_INTERVAL}
+  validation.interval: ${VALIDATION_INTERVAL}
+  validation.attempts.threshold: ${VALIDATION_ATTEMPTS_THRESHOLD}
+  validation.percentage.threshold: ${VALIDATION_PERCENTAGE_THRESHOLD}
+  init.validation.interval: ${VALIDATION_INTERVAL_INIT}
+  init.validation.attempts.threshold: ${VALIDATION_ATTEMPTS_THRESHOLD_INIT}
+  init.validation.percentage.threshold: ${VALIDATION_PERCENTAGE_THRESHOLD}
+  connect.cluster: ${CONNECT_CLUSTER}
+  connector.allowlist.sp: ${CONNECTOR_ALLOWLIST_SP}
+  db.ssl.mode: ${SSL_MODE}
+  db.ssl.root.cert: ${SSL_ROOT_CERT}
+  refresh: ${REFRESH}
+  connector.topic: ${CONNECTOR_TOPIC}
+  connector.topic.replication.factor: ${DLQ_TOPIC_REPLICATION_FACTOR}
+  connector.deadletterqueue.topic.name: ${DLQ_TOPIC_NAME}

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,5 +1,5 @@
 # Adds namespace to all resources.
-namespace: cyndi-operator-system
+#namespace: cyndi-operator-system
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named
@@ -16,6 +16,9 @@ bases:
 - ../crd
 - ../rbac
 - ../manager
+
+resources:
+- cyndi_configmap.yaml
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- ../webhook

--- a/config/deployment-template/cyndi_configmap.yaml
+++ b/config/deployment-template/cyndi_configmap.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cyndi
+data:
+  connector.allowlist.sp: ${CONNECTOR_ALLOWLIST_SP}
+  inventory.dbSecret: ${HOST_INVENTORY_DB_SECRET}
+  standard.interval: ${RECONCILE_INTERVAL}
+  validation.interval: ${VALIDATION_INTERVAL}
+  validation.attempts.threshold: ${VALIDATION_ATTEMPTS_THRESHOLD}
+  validation.percentage.threshold: ${VALIDATION_PERCENTAGE_THRESHOLD}
+  init.validation.interval: ${VALIDATION_INTERVAL_INIT}
+  init.validation.attempts.threshold: ${VALIDATION_ATTEMPTS_THRESHOLD_INIT}
+  init.validation.percentage.threshold: ${VALIDATION_PERCENTAGE_THRESHOLD}
+  connect.cluster: ${CONNECT_CLUSTER}
+  connector.allowlist.sp: ${CONNECTOR_ALLOWLIST_SP}
+  db.ssl.mode: ${SSL_MODE}
+  db.ssl.root.cert: ${SSL_ROOT_CERT}
+  refresh: ${REFRESH}
+  connector.topic: ${CONNECTOR_TOPIC}
+  connector.topic.replication.factor: ${DLQ_TOPIC_REPLICATION_FACTOR}
+  connector.deadletterqueue.topic.name: ${DLQ_TOPIC_NAME}

--- a/config/deployment-template/kustomization.yaml
+++ b/config/deployment-template/kustomization.yaml
@@ -1,0 +1,72 @@
+# Adds namespace to all resources.
+#namespace: cyndi-operator-system
+
+# Value of this field is prepended to the
+# names of all resources, e.g. a deployment named
+# "wordpress" becomes "alices-wordpress".
+# Note that it should also match with the prefix (text before '-') of the namespace
+# field above.
+namePrefix: cyndi-operator-
+
+# Labels to add to all resources and selectors.
+#commonLabels:
+#  someName: someValue
+
+bases:
+- ../crd
+- ../rbac
+- ../manager
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
+# crd/kustomization.yaml
+#- ../webhook
+# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
+#- ../certmanager
+# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
+#- ../prometheus
+
+  # Protect the /metrics endpoint by putting it behind auth.
+  # If you want your controller-manager to expose the /metrics
+  # endpoint w/o any authn/z, please comment the following line.
+patchesStrategicMerge:
+- manager.yaml
+- cyndi_configmap.yaml
+  #- manager_auth_proxy_patch.yaml
+
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
+# crd/kustomization.yaml
+#- manager_webhook_patch.yaml
+
+# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
+# Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
+# 'CERTMANAGER' needs to be enabled to use ca injection
+#- webhookcainjection_patch.yaml
+
+# the following config is for teaching kustomize how to do var substitution
+vars: []
+# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
+#- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
+#  objref:
+#    kind: Certificate
+#    group: cert-manager.io
+#    version: v1alpha2
+#    name: serving-cert # this name should match the one in certificate.yaml
+#  fieldref:
+#    fieldpath: metadata.namespace
+#- name: CERTIFICATE_NAME
+#  objref:
+#    kind: Certificate
+#    group: cert-manager.io
+#    version: v1alpha2
+#    name: serving-cert # this name should match the one in certificate.yaml
+#- name: SERVICE_NAMESPACE # namespace of the service
+#  objref:
+#    kind: Service
+#    version: v1
+#    name: webhook-service
+#  fieldref:
+#    fieldpath: metadata.namespace
+#- name: SERVICE_NAME
+#  objref:
+#    kind: Service
+#    version: v1
+#    name: webhook-service

--- a/config/deployment-template/manager.yaml
+++ b/config/deployment-template/manager.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+spec:
+  template:
+    spec:
+      containers:
+      - image: ${IMAGE}:${IMAGE_TAG}
+        name: manager

--- a/config/manager/cyndi_configmap.yaml
+++ b/config/manager/cyndi_configmap.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cyndi
+data:
+  inventory.dbSecret: host-inventory-db
+  connector.allowlist.sp: >-
+    ansible,sap,sap_system,sap_sids,operating_system,owner_id,rhc_client_id,rhsm,bios_vendor,bios_version,bios_release_date,infrastructure_type,host_type,mssql,system_update_method
+  validation.percentage.threshold: '15'
+  connector.topic: platform.inventory.events
+  init.validation.percentage.threshold: '15'
+  connector.topic.replication.factor: '1'
+  connector.deadletterqueue.topic.name: platform.cyndi.dlq
+  db.ssl.mode: verify-full
+  standard.interval: '120'
+  connect.cluster: insights-kafka-connect
+  validation.attempts.threshold: '2'
+  validation.interval: '1800'
+  init.validation.attempts.threshold: '60'
+  refresh: '1666032490'
+  init.validation.interval: '60'
+  db.ssl.root.cert: /opt/kafka/external-configuration/rds-client-ca/rds-cacert
+

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
 - manager.yaml
+- cyndi_configmap.yaml
 
 configMapGenerator:
 - files:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -1,15 +1,7 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  labels:
-    control-plane: controller-manager
-  name: system
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: controller-manager
-  namespace: system
   labels:
     control-plane: controller-manager
 spec:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -41,9 +41,18 @@ spec:
           requests:
             cpu: 100m
             memory: 2Gi
+        volumeMounts:
+            - mountPath: /opt/kafka/external-configuration/rds-client-ca
+              name: rds-client-ca
         ports:
         - name: metrics
           containerPort: 8080
           protocol: TCP
+      volumes:
+        - name: rds-client-ca
+          secret:
+            secretName: rds-client-ca
+            defaultMode: 420
+            optional: true
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -7,7 +7,10 @@ resources:
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.
-- auth_proxy_service.yaml
-- auth_proxy_role.yaml
-- auth_proxy_role_binding.yaml
-- auth_proxy_client_clusterrole.yaml
+  #- auth_proxy_service.yaml
+  #- auth_proxy_role.yaml
+  #- auth_proxy_role_binding.yaml
+  #- auth_proxy_client_clusterrole.yaml
+  #
+patchesStrategicMerge:
+- role_binding.yaml

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -1,12 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: cyndi-operator-leader-election-rolebinding
+  name: leader-election-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: cyndi-operator-leader-election-role
+  name: leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
-  namespace: system
+  name: cyndi-operator-controller-manager

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -1,12 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: cyndi-operator-manager-rolebinding
+  name: manager-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: cyndi-operator-manager-role
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
-  namespace: system
+  name: cyndi-operator-controller-manager
+  namespace: ${TARGET_NAMESPACE}

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -2,4 +2,3 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: controller-manager
-  namespace: system

--- a/manifest2template.py
+++ b/manifest2template.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+
+import yaml
+import sys
+
+yamls = yaml.safe_load_all(sys.stdin)
+
+with open("template.yml") as fp:
+    template = yaml.safe_load(fp)
+
+template["objects"].extend(yamls)
+
+print(yaml.dump(template))

--- a/template.yml
+++ b/template.yml
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: cyndi-operator
+parameters:
+- name: IMAGE_TAG
+  value: latest
+- name: IMAGE
+  value: quay.io/cloudservices/cyndi-operator
+- name: TARGET_NAMESPACE
+  value: cyndi
+- name: SOURCE_NAMESPACE
+  value: cyndi
+- name: RECONCILE_INTERVAL
+  value: "120"
+- name: VALIDATION_INTERVAL
+  value: "1800"
+- name: VALIDATION_INTERVAL_INIT
+  value: "60"
+- name: VALIDATION_PERCENTAGE_THRESHOLD
+  value: "5"
+- name: VALIDATION_ATTEMPTS_THRESHOLD
+  value: "3"
+- name: VALIDATION_ATTEMPTS_THRESHOLD_INIT
+  value: "30"
+- name: CONNECT_CLUSTER
+  value: "xjoin-kafka-connect-strimzi"
+- name: CONNECTOR_ALLOWLIST_SP
+  value: "sap_system,sap_sids"
+- name: SSL_MODE
+  value: verify-full
+- name: SSL_ROOT_CERT
+  value: /opt/kafka/external-configuration/rds-client-ca/rds-cacert
+- name: EPHEMERAL
+  value: "false"
+- name: REFRESH
+  value: "1633013215"
+- name: MANAGER_POD_CPU_REQUESTS
+  value: "500m"
+- name: MANAGER_POD_MEM_REQUESTS
+  value: "2Gi"
+- name: MANAGER_POD_CPU_LIMIT
+  value: "1"
+- name: MANAGER_POD_MEM_LIMIT
+  value: "4Gi"
+- name: CONNECTOR_TOPIC
+  value: "platform.inventory.events"
+- name: DLQ_TOPIC_NAME
+  value: "platform.cyndi.dlq"
+- name: DLQ_TOPIC_REPLICATION_FACTOR
+  value: "1"
+- name: HOST_INVENTORY_DB_SECRET
+  value: "host-inventory-read-only-db"
+objects: []


### PR DESCRIPTION
This change sets up cyndi so that it can be removed from OLM. The main reason for this is that the catalog and index images have _very_ old CVEs and are not necessary for cyndi to do its job. This PR takes its inspiration from Clowder which also dropped OLM dependency.

We add a new build-template Make command that will generate a deploy.yml that can be referenced directly from app-interface just like any other app or image.

If commercial decides to take this approach, follow these steps:

1. Generate the deploy.yml by running `make build-tempalte`
2. Create a new resourceTemplate in the cyndi/xjoin deploy file that references this new deploy.yml
3. Create a new target in this resourceTemplate and copy the old cyndi params into it
4. Delete the cyndi-operator using `delete: true` in the old resourceTemplate for the namespace you're updating. This way the operator will be deleted at the same time the new controller is created
5. Submit the change to app-interface

You will likely have to manually delete the operator from the Installed Operators tab as the clusterServiceVersion doesn't get removed by app-interface
You'll also need to delete the cyndi-operator-manager-rolebinding because the operator doesn't clear that either. You'll likely need appSRE to do this for you. I know I didn't have access to do it.

After the controller goes in, it will pick up the pipelines and begin working just like the OLM dependent version did. You can monitor the logs of cyndi-operator-controller-manager to validate that it works.

Tadah! No more cyndi-catalog-source

Pipeliens are still accessible by searching using the Search tab in the left naviagation of the Openshift Console, or by using `oc get cyndipipelines -A` in the command line.