### PR TITLE
Use the kafka-connect image patched for security fixes and used by Fedramp

### DIFF
--- a/dev/kafka-connect.yaml
+++ b/dev/kafka-connect.yaml
@@ -8,7 +8,7 @@ metadata:
   # needing to call the Connect REST API directly
     strimzi.io/use-connector-resources: "true"
 spec:
-  image: quay.io/cloudservices/xjoin-kafka-connect-strimzi:latest
+  image: quay.io/cloudservices/insights-kafka-connect:latest
   version: 2.6.2
   replicas: 1
   bootstrapServers: my-cluster-kafka-bootstrap:9093


### PR DESCRIPTION
rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED

The PR replaces the old xjoin-kafka-connect-strizmi with the new `insights-kafka-connect` image used by Fedramp.  In Fedramp it appears to meet their requirements.  That's why adding it to the Cyndi-operator, which needs kafka-connect.