### PR TITLE
fix(CI): use jq in checkimage

### DIFF
--- a/.github/workflows/checkimage.yaml
+++ b/.github/workflows/checkimage.yaml
@@ -16,7 +16,7 @@ jobs:
         run: |
           baseimage=$(grep -Po '(?<=FROM )(.* as builder)' Dockerfile)
           base=${baseimage% as builder}
-          skopeo inspect "docker://$base" | grep -Po '(?<="Digest": ")([^"]+)' > .baseimagedigest
+          skopeo inspect "docker://$base" | jq .Digest --raw-output > .baseimagedigest
       - name: Do change if the digest changed
         run: |
           git config user.name 'Update-a-Bot'


### PR DESCRIPTION
Use jq to query for image digest to remove the need to rely on skopeo inspect output having json keys in particular order. RHINENG-13679