### PR TITLE
task: Update pause spec to state due to deprecation warning

### DIFF
--- a/controllers/connect/connect.go
+++ b/controllers/connect/connect.go
@@ -148,7 +148,7 @@ func newConnectorResource(name string, namespace string, config ConnectorConfigu
 			"tasksMax": config.TasksMax,
 			"class":    "io.confluent.connect.jdbc.JdbcSinkConnector",
 			"config":   configTemplateInterface,
-			"pause":    false,
+			"state":    "running",
 		},
 	}
 

--- a/controllers/connect/connect_test.go
+++ b/controllers/connect/connect_test.go
@@ -156,7 +156,7 @@ var _ = Describe("Connect", func() {
 			Expect(spec).To(HaveKey("config"))
 			Expect(spec).To(HaveKeyWithValue("class", "io.confluent.connect.jdbc.JdbcSinkConnector"))
 			Expect(spec).To(HaveKeyWithValue("tasksMax", int64(64)))
-			Expect(spec).To(HaveKeyWithValue("pause", false))
+			Expect(spec).To(HaveKeyWithValue("state", "running"))
 
 			Expect(spec["config"]).To(HaveKeyWithValue("tasks.max", "64"))
 			Expect(spec["config"]).To(HaveKeyWithValue("topics", "platform.inventory.events"))

--- a/test/crd/047-Crd-kafkaconnector.yaml
+++ b/test/crd/047-Crd-kafkaconnector.yaml
@@ -64,9 +64,9 @@ spec:
                 type: object
                 description: 'The Kafka Connector configuration. The following properties
                   cannot be set: connector.class, tasks.max.'
-              pause:
-                type: boolean
-                description: Whether the connector should be paused. Defaults to false.
+              state:
+                type: string
+                description: The state the connector should be in. Defaults to running.
             description: The specification of the Kafka Connector.
           status:
             type: object


### PR DESCRIPTION
Strimzi has deprecated the `pause` spec and has advised that we begin using `state` instead.

Updating this due to the warning we're seeing commercial stage and fedramp prod.
https://strimzi.io/docs/operators/0.38.0/configuring#type-KafkaConnectorSpec-reference