### PR TITLE
Move last_check_in to end of view and table definitions

### DIFF
--- a/controllers/config/defaults.go
+++ b/controllers/config/defaults.go
@@ -99,14 +99,14 @@ CREATE TABLE inventory.{{.TableName}} (
 	tags jsonb NOT NULL,
 	updated timestamp with time zone NOT NULL,
 	created timestamp with time zone NOT NULL,
-	last_check_in timestamp with time zone NOT NULL,
 	stale_timestamp timestamp with time zone NOT NULL,
 	system_profile jsonb NOT NULL,
 	insights_id uuid,
 	reporter character varying(255) NOT NULL,
 	per_reporter_staleness jsonb NOT NULL,
 	org_id character varying(36),
-	groups jsonb
+	groups jsonb,
+	last_check_in timestamp with time zone NOT NULL
 );
 `
 

--- a/controllers/database/app_database.go
+++ b/controllers/database/app_database.go
@@ -21,7 +21,6 @@ const viewTemplate = `CREATE OR REPLACE VIEW inventory.hosts AS SELECT
 	display_name,
 	created,
 	updated,
-	last_check_in,
 	stale_timestamp,
 	stale_timestamp + INTERVAL '1' DAY * '%[2]s' AS stale_warning_timestamp,
 	stale_timestamp + INTERVAL '1' DAY * '%[3]s' AS culled_timestamp,
@@ -31,7 +30,8 @@ const viewTemplate = `CREATE OR REPLACE VIEW inventory.hosts AS SELECT
 	reporter,
 	per_reporter_staleness,
 	org_id,
-	groups
+	groups,
+	last_check_in
 FROM inventory.%[1]s`
 
 const cullingStaleWarningOffset = "7"


### PR DESCRIPTION
We're currently hitting this error:
```
Error updating hosts view: Error executing query CREATE OR REPLACE VIEW inventory.hosts AS SELECT id, account, display_name, created, updated, last_check_in, stale_timestamp, stale_timestamp + INTERVAL '1' DAY * '7' AS stale_warning_timestamp, stale_timestamp + INTERVAL '1' DAY * '14' AS culled_timestamp, tags, system_profile, insights_id, reporter, per_reporter_staleness, org_id, groups FROM inventory.hosts_v1_1748967388197128703, ERROR: cannot change name of view column "stale_timestamp" to "last_check_in" (SQLSTATE 42P16)
```
This appears to be because the view already exists, and last_check_in was inserted in-between two columns. I'm moving it to the end, which will hopefully resolve this issue.