### PR TITLE
Use controller-tools still compatible with go 1.22

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ ifeq (, $(shell which controller-gen))
 	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
 	cd $$CONTROLLER_GEN_TMP_DIR ;\
 	go mod init tmp ;\
-	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.16.5 ;\
+	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.15.0 ;\
 	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
 	}
 CONTROLLER_GEN=$(GOBIN)/controller-gen


### PR DESCRIPTION
CI (Jenkins) uses Go 1.22, lets try to use compatible controller and revert the big bump in 7591d4fcb0175516fa3c31282f4190402aeaf339 a bit.