### PR TITLE
build(deps): Bump to latest 1.23 build image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi9/go-toolset:1.23-1751375493 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.23-1751538372 as builder
 
 USER 0
 WORKDIR /workspace


### PR DESCRIPTION
This will pull latest 1.23 without upgrading to 1.24 go.
This will also rebuild the operator on latest UBI image.